### PR TITLE
OSOE-935: Removing temporary xUnit, Microsoft.NET.Test.Sdk update disables

### DIFF
--- a/default-dotnet.json5
+++ b/default-dotnet.json5
@@ -23,13 +23,5 @@
             'matchUpdateTypes': ['major'],
             enabled: false
         },
-        {
-            // Will be done in https://lombiq.atlassian.net/browse/OSOE-935.
-            matchPackageNames: [
-                'Microsoft.NET.Test.Sdk',
-                'xunit*',
-            ],
-            enabled: false,
-        },
     ]
 }


### PR DESCRIPTION
[OSOE-935](https://lombiq.atlassian.net/browse/OSOE-935)

[OSOE-935]: https://lombiq.atlassian.net/browse/OSOE-935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ