### PR TITLE
OSOE-1193: Removing minimumReleaseAge configs

### DIFF
--- a/default-orchard-core-superproject.json5
+++ b/default-orchard-core-superproject.json5
@@ -8,6 +8,8 @@
             // being referenced by both the superproject and a submodule), we update all dependencies at once.
             groupName: 'All Dependencies',
             matchUpdateTypes: ['*'],
+            // This is so major updates won't be put in a separate branch.
+            branchName: 'renovate/all-dependencies',
         },
     ],
 }

--- a/default-orchard-core-superproject.json5
+++ b/default-orchard-core-superproject.json5
@@ -8,8 +8,8 @@
             // being referenced by both the superproject and a submodule), we update all dependencies at once.
             groupName: 'All Dependencies',
             matchUpdateTypes: ['*'],
-            // This is so major updates won't be put in a separate branch.
-            branchName: 'renovate/all-dependencies',
         },
     ],
+    // This is so major updates won't be put in a separate branch.
+    separateMajorMinor: false,
 }

--- a/default.json5
+++ b/default.json5
@@ -23,12 +23,12 @@
         // Wait 15 days after a major/minor release, and if there's a patch release since then, update to that right
         // away. This is to avoid updating if bugfixes soon follow releases. 
         {
-            "matchUpdateTypes": ['major', 'minor'],
-            "minimumReleaseAge": '15 days',
+            'matchUpdateTypes': ['major', 'minor'],
+            'minimumReleaseAge': '15 days',
         },
         {
-            "matchUpdateTypes": ['patch'],
-            "minimumReleaseAge": '0 days',
+            'matchUpdateTypes': ['patch'],
+            'minimumReleaseAge': '0 days',
         },
         {
             groupName: 'Submodules',

--- a/default.json5
+++ b/default.json5
@@ -5,19 +5,13 @@
     $schema: 'https://docs.renovatebot.com/renovate-schema.json',
     description: 'Default Lombiq Renovate configuration.',
     extends: [
-        'config:recommended',
-        ':enableVulnerabilityAlerts',
-        'docker:pinDigests',
-        'helpers:pinGitHubActionDigests',
-        ':pinDevDependencies'
+        // See https://docs.renovatebot.com/presets-config/#configbest-practices.
+        'config:best-practices',
     ],
     addLabels: [
         'dependencies',
         'renovate',
     ],
-    // See https://docs.renovatebot.com/configuration-options/#configmigration. This always uses single quotes, so we
-    // use those too.
-    configMigration: true,
     dependencyDashboard: false,
     packageRules: [
         // Wait 15 days after a major/minor release, and if there's a patch release since then, update to that right

--- a/default.json5
+++ b/default.json5
@@ -23,12 +23,12 @@
         // Wait 15 days after a major/minor release, and if there's a patch release since then, update to that right
         // away. This is to avoid updating if bugfixes soon follow releases. 
         {
-            'matchUpdateTypes': ['major', 'minor'],
-            'minimumReleaseAge': '15 days',
+            matchUpdateTypes: ['major', 'minor'],
+            minimumReleaseAge: '15 days',
         },
         {
-            'matchUpdateTypes': ['patch'],
-            'minimumReleaseAge': '0 days',
+            matchUpdateTypes: ['patch'],
+            minimumReleaseAge: '0 days',
         },
         {
             groupName: 'Submodules',

--- a/default.json5
+++ b/default.json5
@@ -14,21 +14,6 @@
     ],
     dependencyDashboard: false,
     packageRules: [
-        // Wait 15 days after a major/minor release, and if there's a patch release since then, update to that right
-        // away. This is to avoid updating if bugfixes soon follow releases. 
-        {
-            matchUpdateTypes: ['major', 'minor'],
-            minimumReleaseAge: '15 days',
-        },
-        {
-            matchUpdateTypes: ['patch'],
-            minimumReleaseAge: '0 days',
-        },
-        {
-            groupName: 'Submodules',
-            matchManagers: ['git-submodules'],
-            minimumReleaseAge: '0 days',
-        },
         {
             groupName: 'Lombiq packages',
             matchPackageNames: [
@@ -41,6 +26,13 @@
         {
             groupName: 'Patch Dependency Versions',
             matchUpdateTypes: ['patch', 'pin', 'pinDigest'],
+        },
+        {
+            groupName: 'Submodules',
+            matchManagers: ['git-submodules'],
+            // Even if the minimumReleaseAge is configured for other dependencies, submodules, since they don't have
+            // release timestamps, should be updated right away.
+            minimumReleaseAge: '0 days',
         },
     ],
     // With GitHub Actions, concurrency is not really an issue.


### PR DESCRIPTION
[OSOE-1193](https://lombiq.atlassian.net/browse/OSOE-1193)
Couldn't get them working in a way that when there's a major, then soon a patch update, it updates right to the patch version.

[OSOE-1193]: https://lombiq.atlassian.net/browse/OSOE-1193?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ