### PR TITLE
OSOE-925: Remove update exceptions fore Moq and Scrutor.

### DIFF
--- a/default-dotnet.json5
+++ b/default-dotnet.json5
@@ -48,11 +48,5 @@
             matchPackageNames: ['pnpm'],
             allowedVersions: '<10.0.0',
         },
-        {
-            // Don't upgrade Scrutor until this is fixed: https://github.com/khellang/Scrutor/issues/268.
-            matchPackageNames: [ 'Scrutor'],
-            allowedVersions: '<7.0.0',
-            matchCurrentVersion: '/^6\\./',
-        },
     ],
 }

--- a/default-dotnet.json5
+++ b/default-dotnet.json5
@@ -54,15 +54,5 @@
             allowedVersions: '<7.0.0',
             matchCurrentVersion: '/^6\\./',
         },
-        {
-            // 3.6.0 and later transitively reference Roslyn 4.14.0.0 packages, causing errors of the following kind:
-            // "CSC : error CS9057: The analyzer assembly
-            // '/home/runner/.nuget/packages/moq.automock/3.6.0/analyzers/dotnet/cs/Moq.AutoMocker.Generators.dll'
-            // references version '4.14.0.0' of the compiler, which is newer than the currently running version
-            // '4.10.0.0'." under .NET 8. This needs .NET 10.
-            matchPackageNames: [ 'Moq.AutoMock'],
-            allowedVersions: '<3.6.0',
-            matchCurrentVersion: '/^3\\.5\\./',
-        },
     ],
 }

--- a/default.json5
+++ b/default.json5
@@ -103,6 +103,19 @@
             currentValueTemplate: "master",
             packageNameTemplate: "https://github.com/{{{depName}}}",
             datasourceTemplate: 'git-refs'
+        },
+        {
+            // MSBuild SDK
+            customType: 'regex',
+            managerFilePatterns: [
+                '/.csproj$/',
+            ],
+            matchStrings: [
+                'Sdk="(?<packageName>[^"/]+?)\/(?<currentValue>[^"]+?)"',
+                '<Sdk[^>]+Name="(?<packageName>[^"/]+?)"[^>]+Version="(?<currentValue>[^"]+?)"',
+                '<Import[^>]+Sdk="(?<packageName>[^"/]+?)"[^>]+Version="(?<currentValue>[^"]+?)"'
+            ],
+            datasourceTemplate: 'nuget'
         }
     ],
 }


### PR DESCRIPTION
[OSOE-925](https://lombiq.atlassian.net/browse/OSOE-925)

[OSOE-925]: https://lombiq.atlassian.net/browse/OSOE-925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ